### PR TITLE
Improve example test `testPatcher` and increase caching speed

### DIFF
--- a/src/main/kotlin/net/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/net/revanced/patcher/Patcher.kt
@@ -7,7 +7,6 @@ import net.revanced.patcher.signature.Signature
 import net.revanced.patcher.util.Jar2ASM
 import java.io.InputStream
 import java.io.OutputStream
-import java.util.jar.JarOutputStream
 
 /**
  * The patcher. (docs WIP)
@@ -20,12 +19,12 @@ class Patcher(
     private val input: InputStream,
     signatures: Array<Signature>,
 ) {
-    val cache = Cache()
+    var cache: Cache
     private val patches: MutableList<Patch> = mutableListOf()
 
     init {
-        cache.classes.putAll(Jar2ASM.jar2asm(input))
-        cache.methods.putAll(MethodResolver(cache.classes.values.toList(), signatures).resolve())
+        val classes = Jar2ASM.jar2asm(input);
+        cache = Cache(classes, MethodResolver(classes, signatures).resolve())
     }
 
     fun addPatches(vararg patches: Patch) {

--- a/src/main/kotlin/net/revanced/patcher/cache/Cache.kt
+++ b/src/main/kotlin/net/revanced/patcher/cache/Cache.kt
@@ -2,14 +2,14 @@ package net.revanced.patcher.cache
 
 import org.objectweb.asm.tree.ClassNode
 
-class Cache {
-    val classes: MutableMap<String, ClassNode> = mutableMapOf()
-    val methods: MethodMap = MethodMap()
-}
+class Cache (
+    val classes: List<ClassNode>,
+    val methods: MethodMap
+)
 
 class MethodMap : LinkedHashMap<String, PatchData>() {
     override fun get(key: String): PatchData {
-        return super.get(key) ?: throw MethodNotFoundException("Method $key not found in method cache")
+        return super.get(key) ?: throw MethodNotFoundException("Method $key was not found in the method cache")
     }
 }
 

--- a/src/main/kotlin/net/revanced/patcher/cache/PatchData.kt
+++ b/src/main/kotlin/net/revanced/patcher/cache/PatchData.kt
@@ -4,12 +4,12 @@ import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
 
 data class PatchData(
-    val cls: ClassNode,
+    val declaringClass: ClassNode,
     val method: MethodNode,
-    val sd: ScanData
+    val scanData: PatternScanData
 )
 
-data class ScanData(
+data class PatternScanData(
     val startIndex: Int,
     val endIndex: Int
 )

--- a/src/main/kotlin/net/revanced/patcher/util/Jar2ASM.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Jar2ASM.kt
@@ -10,21 +10,20 @@ import java.util.jar.JarInputStream
 import java.util.jar.JarOutputStream
 
 object Jar2ASM {
-    fun jar2asm(input: InputStream): Map<String, ClassNode> {
-        return buildMap {
-            val jar = JarInputStream(input)
+    fun jar2asm(input: InputStream) = mutableListOf<ClassNode>().apply {
+        val jar = JarInputStream(input)
             while (true) {
                 val e = jar.nextJarEntry ?: break
                 if (e.name.endsWith(".class")) {
                     val classNode = ClassNode()
                     ClassReader(jar.readAllBytes()).accept(classNode, ClassReader.EXPAND_FRAMES)
-                    this[e.name] = classNode
+                        this.add(classNode)
                 }
                 jar.closeEntry()
             }
-        }
     }
-    fun asm2jar(input: InputStream, output: OutputStream, structure: Map<String, ClassNode>) {
+
+    fun asm2jar(input: InputStream, output: OutputStream, classes: List<ClassNode>) {
         val jis = JarInputStream(input)
         val jos = JarOutputStream(output)
 
@@ -33,10 +32,13 @@ object Jar2ASM {
             val next = jis.nextJarEntry ?: break
             val e = JarEntry(next) // clone it, to not modify the input (if possible)
             jos.putNextEntry(e)
-            if (structure.containsKey(e.name)) {
+
+            val clazz = classes.singleOrNull {
+                    clazz -> clazz.name == e.name
+            };
+            if (clazz != null) {
                 val cw = ClassWriter(ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES)
-                val cn = structure[e.name]!!
-                cn.accept(cw)
+                clazz.accept(cw)
                 jos.write(cw.toByteArray())
             } else {
                 jos.write(jis.readAllBytes())


### PR DESCRIPTION
This PR increases the speed of caching the methods and classes. Instead of moving all the methods and classes from one to another map or list we simply instantiate the Cache with them. Additionally the example test `testPatcher` has been improved.