### PR TITLE
fix(Io): JAR loading and saving

### DIFF
--- a/src/main/kotlin/net/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/net/revanced/patcher/Patcher.kt
@@ -6,16 +6,19 @@ import net.revanced.patcher.resolver.MethodResolver
 import net.revanced.patcher.signature.Signature
 import net.revanced.patcher.util.Io
 import org.objectweb.asm.tree.ClassNode
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
 /**
- * The patcher. (docs WIP)
+ * The Patcher class.
+ * ***It is of utmost importance that the input and output streams are NEVER closed.***
  *
  * @param input the input stream to read from, must be a JAR
- * @param output the output stream to write to, must be a JAR
+ * @param output the output stream to write to
  * @param signatures the signatures
  * @sample net.revanced.patcher.PatcherTest
+ * @throws IOException if one of the streams are closed
  */
 class Patcher(
     private val input: InputStream,
@@ -34,6 +37,13 @@ class Patcher(
         cache = Cache(classes, MethodResolver(classes, signatures).resolve())
     }
 
+    /**
+     * Saves the output to the output stream.
+     * Calling this method will close the input and output streams,
+     * meaning this method should NEVER be called after.
+     *
+     * @throws IOException if one of the streams are closed
+     */
     fun save() {
         io.saveAsJar()
     }

--- a/src/main/kotlin/net/revanced/patcher/cache/Cache.kt
+++ b/src/main/kotlin/net/revanced/patcher/cache/Cache.kt
@@ -2,7 +2,7 @@ package net.revanced.patcher.cache
 
 import org.objectweb.asm.tree.ClassNode
 
-class Cache (
+class Cache(
     val classes: List<ClassNode>,
     val methods: MethodMap
 )

--- a/src/main/kotlin/net/revanced/patcher/cache/PatchData.kt
+++ b/src/main/kotlin/net/revanced/patcher/cache/PatchData.kt
@@ -10,6 +10,7 @@ data class PatchData(
     val method: MethodNode,
     val scanData: PatternScanData
 ) {
+    @Suppress("Unused") // TODO(Sculas): remove this when we have coverage for this method.
     fun findParentMethod(signature: Signature): PatchData? {
         return MethodResolver.resolveMethod(declaringClass, signature)
     }

--- a/src/main/kotlin/net/revanced/patcher/cache/PatchData.kt
+++ b/src/main/kotlin/net/revanced/patcher/cache/PatchData.kt
@@ -11,7 +11,7 @@ data class PatchData(
     val scanData: PatternScanData
 ) {
     fun findParentMethod(signature: Signature): PatchData? {
-       return MethodResolver.resolveMethod(declaringClass, signature)
+        return MethodResolver.resolveMethod(declaringClass, signature)
     }
 }
 

--- a/src/main/kotlin/net/revanced/patcher/util/Io.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Io.kt
@@ -26,10 +26,10 @@ internal class Io(
 
         // read all entries from the input stream
         // we use JarEntry because we only read .class files
-        var jarEntry: JarEntry?
-        while (jis.nextJarEntry.also { jarEntry = it } != null) {
+        lateinit var jarEntry: JarEntry
+        while (jis.nextJarEntry.also { if (it != null) jarEntry = it } != null) {
             // if the current entry ends with .class (indicating a java class file), add it to our list of classes to return
-            if (jarEntry!!.name.endsWith(".class")) {
+            if (jarEntry.name.endsWith(".class")) {
                 // create a new ClassNode
                 val classNode = ClassNode()
                 // read the bytes with a ClassReader into the ClassNode
@@ -59,7 +59,7 @@ internal class Io(
             if (zipEntry.name.endsWith(".class")) continue
 
             // create a new zipEntry and write the contents of the zipEntry to the output stream
-            jos.putNextEntry(ZipEntry(zipEntry.name))
+            jos.putNextEntry(ZipEntry(zipEntry))
             jos.write(jis.readBytes())
 
             // close the newly created zipEntry

--- a/src/main/kotlin/net/revanced/patcher/util/Io.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Io.kt
@@ -16,13 +16,12 @@ internal class Io(
     private val input: InputStream,
     private val output: OutputStream,
     private val classes: MutableList<ClassNode>
-    )
-{
+) {
     private val bufferedInputStream = BufferedInputStream(input)
 
     fun readFromJar() {
         bufferedInputStream.mark(0)
-       // create a BufferedInputStream in order to read the input stream again when calling saveAsJar(..)
+        // create a BufferedInputStream in order to read the input stream again when calling saveAsJar(..)
         val jis = JarInputStream(bufferedInputStream)
 
         // read all entries from the input stream

--- a/src/main/kotlin/net/revanced/patcher/util/Io.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Io.kt
@@ -55,7 +55,7 @@ internal class Io(
         var zipEntry: ZipEntry?
         while (jis.nextEntry.also { zipEntry = it } != null) {
             // skip all class files because we added them in the loop above
-            // TODO: check for zipEntry.isDirectory
+            // TODO(oSumAtrIX): Check for zipEntry.isDirectory
             if (zipEntry!!.name.endsWith(".class")) continue
 
             // create a new zipEntry and write the contents of the zipEntry to the output stream

--- a/src/main/kotlin/net/revanced/patcher/util/Io.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Io.kt
@@ -52,6 +52,7 @@ internal class Io(
 
         // first write all non .class zip entries from the original input stream to the output stream
         // we read it first to close the input stream as fast as possible
+        // TODO(oSumAtrIX): There is currently no way to remove non .class files.
         lateinit var zipEntry: ZipEntry
         while (jis.nextEntry.also { if (it != null) zipEntry = it } != null) {
             // skip all class files because we added them in the loop above

--- a/src/main/kotlin/net/revanced/patcher/util/Io.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Io.kt
@@ -3,47 +3,92 @@ package net.revanced.patcher.util
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.tree.ClassNode
+import java.io.BufferedInputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.jar.JarEntry
 import java.util.jar.JarInputStream
-import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
-object Io {
-    fun readClassesFromJar(input: InputStream) = mutableListOf<ClassNode>().apply {
-        val jar = JarInputStream(input)
-            while (true) {
-                val e = jar.nextJarEntry ?: break
-                if (e.name.endsWith(".class")) {
-                    val classNode = ClassNode()
-                    ClassReader(jar.readBytes()).accept(classNode, ClassReader.EXPAND_FRAMES)
-                    this.add(classNode)
-                }
-                jar.closeEntry()
+internal class Io(
+    private val input: InputStream,
+    private val output: OutputStream,
+    private val classes: MutableList<ClassNode>
+    )
+{
+    private val bufferedInputStream = BufferedInputStream(input)
+
+    fun readFromJar() {
+        bufferedInputStream.mark(0)
+       // create a BufferedInputStream in order to read the input stream again when calling saveAsJar(..)
+        val jis = JarInputStream(bufferedInputStream)
+
+        // read all entries from the input stream
+        // we use JarEntry because we only read .class files
+        var jarEntry: JarEntry?
+        while (jis.nextJarEntry.also { jarEntry = it } != null) {
+            // if the current entry ends with .class (indicating a java class file), add it to our list of classes to return
+            if (jarEntry!!.name.endsWith(".class")) {
+                // create a new ClassNode
+                val classNode = ClassNode()
+                // read the bytes with a ClassReader into the ClassNode
+                ClassReader(jis.readBytes()).accept(classNode, ClassReader.EXPAND_FRAMES)
+                // add it to our list
+                classes.add(classNode)
             }
+
+            // finally, close the entry
+            jis.closeEntry()
+        }
+
+        // at last reset the buffered input stream
+        bufferedInputStream.reset()
     }
 
-    fun writeClassesToJar(input: InputStream, output: OutputStream, classes: List<ClassNode>) {
-        val jis = JarInputStream(input)
-        val jos = JarOutputStream(output)
+    fun saveAsJar() {
+        val jis = ZipInputStream(bufferedInputStream)
+        val jos = ZipOutputStream(output)
 
-        // TODO: Add support for adding new/custom classes
-        while (true) {
-            val next = jis.nextJarEntry ?: break
-            val e = JarEntry(next) // clone it, to not modify the input (if possible)
-            jos.putNextEntry(e)
+        // first write all non .class zip entries from the original input stream to the output stream
+        // we read it first to close the input stream as fast as possible
+        var zipEntry: ZipEntry?
+        while (jis.nextEntry.also { zipEntry = it } != null) {
+            // skip all class files because we added them in the loop above
+            // TODO: check for zipEntry.isDirectory
+            if (zipEntry!!.name.endsWith(".class")) continue
 
-            val clazz = classes.singleOrNull {
-                clazz -> clazz.name+".class" == e.name // clazz.name is the class name only while e.name is the full filename with extension
-            };
-            if (clazz != null) {
-                val cw = ClassWriter(ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES)
-                clazz.accept(cw)
-                jos.write(cw.toByteArray())
-            } else {
-                jos.write(jis.readBytes())
-            }
+            // create a new zipEntry and write the contents of the zipEntry to the output stream
+            jos.putNextEntry(ZipEntry(zipEntry!!.name))
+            jos.write(jis.readBytes())
+
+            // close the newly created zipEntry
             jos.closeEntry()
         }
+
+        // finally, close the input stream
+        jis.close()
+        bufferedInputStream.close()
+        input.close()
+
+
+        // now write all the patched classes to the output stream
+        for (patchedClass in classes) {
+            // create a new entry of the patched class
+            jos.putNextEntry(JarEntry(patchedClass.name + ".class"))
+
+            // parse the patched class to a byte array and write it to the output stream
+            val cw = ClassWriter(ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES)
+            patchedClass.accept(cw)
+            jos.write(cw.toByteArray())
+
+            // close the newly created jar entry
+            jos.closeEntry()
+        }
+
+        // finally, close the rest of the streams
+        jos.close()
+        output.close()
     }
 }

--- a/src/main/kotlin/net/revanced/patcher/util/Io.kt
+++ b/src/main/kotlin/net/revanced/patcher/util/Io.kt
@@ -52,14 +52,14 @@ internal class Io(
 
         // first write all non .class zip entries from the original input stream to the output stream
         // we read it first to close the input stream as fast as possible
-        var zipEntry: ZipEntry?
-        while (jis.nextEntry.also { zipEntry = it } != null) {
+        lateinit var zipEntry: ZipEntry
+        while (jis.nextEntry.also { if (it != null) zipEntry = it } != null) {
             // skip all class files because we added them in the loop above
             // TODO(oSumAtrIX): Check for zipEntry.isDirectory
-            if (zipEntry!!.name.endsWith(".class")) continue
+            if (zipEntry.name.endsWith(".class")) continue
 
             // create a new zipEntry and write the contents of the zipEntry to the output stream
-            jos.putNextEntry(ZipEntry(zipEntry!!.name))
+            jos.putNextEntry(ZipEntry(zipEntry.name))
             jos.write(jis.readBytes())
 
             // close the newly created zipEntry
@@ -70,7 +70,6 @@ internal class Io(
         jis.close()
         bufferedInputStream.close()
         input.close()
-
 
         // now write all the patched classes to the output stream
         for (patchedClass in classes) {

--- a/src/main/kotlin/net/revanced/patcher/writer/ASMWriter.kt
+++ b/src/main/kotlin/net/revanced/patcher/writer/ASMWriter.kt
@@ -7,6 +7,7 @@ object ASMWriter {
     fun InsnList.setAt(index: Int, node: AbstractInsnNode) {
         this[this.get(index)] = node
     }
+
     fun InsnList.insertAt(index: Int = 0, vararg nodes: AbstractInsnNode) {
         this.insert(this.get(index), nodes.toInsnList())
     }

--- a/src/test/kotlin/net/revanced/patcher/PatcherTest.kt
+++ b/src/test/kotlin/net/revanced/patcher/PatcherTest.kt
@@ -12,7 +12,9 @@ import net.revanced.patcher.writer.ASMWriter.setAt
 import org.junit.jupiter.api.assertThrows
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.FieldInsnNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import kotlin.test.Test
@@ -129,13 +131,13 @@ internal class PatcherTest {
 
     @Test
     fun `test patcher with no changes`() {
-        val patcher = Patcher(
-            PatcherTest::class.java.getResourceAsStream("/test1.jar")!!,
-            ByteArrayOutputStream(),
-            testSignatures
-        )
-
-        patcher.save()
+        val testData = PatcherTest::class.java.getResourceAsStream("/test1.jar")!!
+        // val available = testData.available()
+        val out = ByteArrayOutputStream()
+        Patcher(testData, out, testSignatures).save()
+        // FIXME(Sculas): There seems to be a 1-byte difference, not sure what it is.
+        // assertEquals(available, out.size())
+        out.close()
     }
 
     @Test

--- a/src/test/kotlin/net/revanced/patcher/ReaderTest.kt
+++ b/src/test/kotlin/net/revanced/patcher/ReaderTest.kt
@@ -1,12 +1,12 @@
 package net.revanced.patcher
 
+import java.io.ByteArrayOutputStream
 import kotlin.test.Test
 
 internal class ReaderTest {
     @Test
     fun `read jar containing multiple classes`() {
         val testData = PatcherTest::class.java.getResourceAsStream("/test2.jar")!!
-        Patcher(testData, PatcherTest.testSigs) // reusing test sigs from PatcherTest
-        testData.close()
+        Patcher(testData, ByteArrayOutputStream(), PatcherTest.testSignatures) // reusing test sigs from PatcherTest
     }
 }

--- a/src/test/kotlin/net/revanced/patcher/util/TestUtil.kt
+++ b/src/test/kotlin/net/revanced/patcher/util/TestUtil.kt
@@ -17,7 +17,7 @@ object TestUtil {
     private fun AbstractInsnNode.nodeString(): String {
         val sb = NodeStringBuilder()
         when (this) {
-            // TODO: Add more types
+            // TODO(Sculas): Add more types
             is LdcInsnNode -> sb
                 .addType("cst", cst)
             is FieldInsnNode -> sb


### PR DESCRIPTION
## This PR addresses issue #5 and continues PR #7.

Io will now be instantiated with both, input as well as an output stream alongside a mutable class list:
https://github.com/ReVancedTeam/revanced-patcher/blob/0f3db838a05fb376fe974b4a1bb3292888f8c5a0/src/main/kotlin/net/revanced/patcher/util/Io.kt#L13-L17

The streams are used until we call `saveAsJar`. The original streams will be closed:
https://github.com/ReVancedTeam/revanced-patcher/blob/0f3db838a05fb376fe974b4a1bb3292888f8c5a0/src/main/kotlin/net/revanced/patcher/util/Io.kt#L86-L90

When writing, the input stream will be proxied through a  `BufferedInputStream` a second time, all classes will be merged with all non-class file zip entries and written into the output stream:
https://github.com/ReVancedTeam/revanced-patcher/blob/0f3db838a05fb376fe974b4a1bb3292888f8c5a0/src/main/kotlin/net/revanced/patcher/util/Io.kt#L56-L84

### All tests and usages in the patcher have been adjusted accordingly.