### PR TITLE
fix: nullable signature members

### DIFF
--- a/src/main/kotlin/net/revanced/patcher/signature/Signature.kt
+++ b/src/main/kotlin/net/revanced/patcher/signature/Signature.kt
@@ -9,21 +9,19 @@ import org.objectweb.asm.Type
  * Do not use the actual method name, instead try to guess what the method name originally was.
  * If you are unable to guess a method name, doing something like "patch-name-1" is fine too.
  * For example: "override-codec-1".
- * This method name will be used to find the corresponding patch.
+ * This method name will be mapped to the method matching the signature.
  * Even though this is technically not needed for the `findParentMethod` method,
  * it is still recommended giving the method a name, so it can be identified easily.
  * @param returns The return type/signature of the method.
  * @param accessors The accessors of the method.
  * @param parameters The parameter types of the method.
  * @param opcodes The opcode pattern of the method, used to find the method by pattern scanning.
- * ***Only if*** **you are using **`findParentMethod`** are you allowed to specify an empty array.**
- * This parameter will be ignored when using the `findParentMethod` method.
  */
 @Suppress("ArrayInDataClass")
 data class Signature(
     val name: String,
-    val returns: Type,
-    val accessors: Int,
-    val parameters: Array<Type>,
-    val opcodes: Array<Int>
+    val returns: Type?,
+    val accessors: Int?,
+    val parameters: Array<Type>?,
+    val opcodes: Array<Int>?
 )

--- a/src/test/kotlin/net/revanced/patcher/PatcherTest.kt
+++ b/src/test/kotlin/net/revanced/patcher/PatcherTest.kt
@@ -9,13 +9,12 @@ import net.revanced.patcher.util.ExtraTypes
 import net.revanced.patcher.util.TestUtil
 import net.revanced.patcher.writer.ASMWriter.insertAt
 import net.revanced.patcher.writer.ASMWriter.setAt
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.*
 import java.io.PrintStream
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 internal class PatcherTest {
     companion object {
@@ -149,25 +148,21 @@ internal class PatcherTest {
     //}
 
     @Test()
-    fun `should raise an exception because opcodes is empty`() {
+    fun `should not raise an exception if any signature member except the name is missing`() {
         val sigName = "testMethod"
-        val e = assertThrows<IllegalArgumentException>("Should raise an exception because opcodes is empty") {
+
+        assertDoesNotThrow("Should raise an exception because opcodes is empty") {
             Patcher(
                 PatcherTest::class.java.getResourceAsStream("/test1.jar")!!,
                 arrayOf(
                     Signature(
                         sigName,
-                        Type.VOID_TYPE,
-                        ACC_PUBLIC or ACC_STATIC,
-                        arrayOf(ExtraTypes.ArrayAny),
-                        emptyArray() // this is not allowed for non-search signatures!
-                    )
-                )
+                        null,
+                        null,
+                        null,
+                        null
+                    ))
             )
         }
-        assertEquals(
-            "Opcode list for signature $sigName is empty. This is not allowed for non-search signatures.",
-            e.message
-        )
     }
 }


### PR DESCRIPTION
RE: #9 

This commit will allow "partial" signatures. Example usage:

```kt
val showVideoAdsMethodData = cache.methods["show-video-ads"].findParentMethod(
    Signature(
        "show-video-ads-method",
        null,
        null,
        arrayOf(Type.BOOLEAN_TYPE),
        null
    )
) ?: return PatchResultError("Could not find parent method to 'show-video-ads'")
```

This example will try to use the cached method `show-video-ads` to find the actual method `show-video-ads-method`. To find this method in our example, it is only required to match for the parameters, since in our example, no other method in the same class has this parameter.