### PR TITLE
refactor: Optimize Signature class

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/resolver/MethodResolver.kt
+++ b/src/main/kotlin/app/revanced/patcher/resolver/MethodResolver.kt
@@ -131,7 +131,7 @@ private operator fun ClassNode.component2(): List<MethodNode> {
     return this.methods
 }
 
-private fun InsnList.scanFor(pattern: Array<Int>): ScanResult {
+private fun InsnList.scanFor(pattern: IntArray): ScanResult {
     for (i in 0 until this.size()) {
         var occurrence = 0
         while (i + occurrence < this.size()) {

--- a/src/main/kotlin/app/revanced/patcher/signature/Signature.kt
+++ b/src/main/kotlin/app/revanced/patcher/signature/Signature.kt
@@ -23,5 +23,5 @@ data class Signature(
     val returns: Type?,
     val accessors: Int?,
     val parameters: Array<Type>?,
-    val opcodes: Array<Int>?
+    val opcodes: IntArray?
 )

--- a/src/test/kotlin/app/revanced/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/revanced/patcher/PatcherTest.kt
@@ -38,7 +38,7 @@ internal class PatcherTest {
                 Type.VOID_TYPE,
                 ACC_PUBLIC or ACC_STATIC,
                 arrayOf(ExtraTypes.ArrayAny),
-                arrayOf(
+                intArrayOf(
                     LDC,
                     INVOKEVIRTUAL
                 )


### PR DESCRIPTION
Changes:
- Change `Array<Int>` references to `IntArray`
---------------------------------------------------
This is to ensure no unnecessary boxing/unboxing happens when running the patcher.

This will break current patches, but migration is really easy - change all `arrayOf()` occurrences for `opcode` to `intArrayOf()`. If this PR gets merged, I'd be glad to migrate the [current patches](https://github.com/ReVancedTeam/revanced-patches) myself.