### PR TITLE
feat: string signature

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/signature/MethodSignature.kt
+++ b/src/main/kotlin/app/revanced/patcher/signature/MethodSignature.kt
@@ -92,14 +92,14 @@ interface PatternScanMethod {
 
         /**
          * Represents a resolver warning.
-         * @param expected The opcode the signature expected it to be.
-         * @param current The current opcode in the pattern. Always different from [expected].
+         * @param correctOpcode The opcode the signature expected it to be.
+         * @param wrongOpcode The opcode the signature currently has.
          * @param instructionIndex The index of the opcode relative to the instruction list.
          * @param patternIndex The index of the opcode relative to the pattern list from the signature.
          */
         data class Warning(
-            val expected: Opcode,
-            val current: Opcode,
+            val correctOpcode: Opcode,
+            val wrongOpcode: Opcode,
             val instructionIndex: Int,
             val patternIndex: Int,
         )

--- a/src/main/kotlin/app/revanced/patcher/signature/MethodSignature.kt
+++ b/src/main/kotlin/app/revanced/patcher/signature/MethodSignature.kt
@@ -19,7 +19,7 @@ class MethodSignature(
     internal val accessFlags: Int?,
     internal val methodParameters: Iterable<String>?,
     internal val opcodes: Iterable<Opcode?>?,
-    internal val strings: Iterable<String>?
+    internal val strings: Iterable<String>? = null
 ) {
     /**
      * The result of the signature

--- a/src/main/kotlin/app/revanced/patcher/signature/MethodSignature.kt
+++ b/src/main/kotlin/app/revanced/patcher/signature/MethodSignature.kt
@@ -10,6 +10,7 @@ import org.jf.dexlib2.Opcode
  * @param accessFlags The access flags of the method.
  * @param methodParameters The parameters of the method.
  * @param opcodes The list of opcodes of the method.
+ * @param strings A list of strings which a method contains.
  * A `null` opcode is equals to an unknown opcode.
  */
 class MethodSignature(
@@ -17,7 +18,8 @@ class MethodSignature(
     internal val returnType: String?,
     internal val accessFlags: Int?,
     internal val methodParameters: Iterable<String>?,
-    internal val opcodes: Iterable<Opcode?>?
+    internal val opcodes: Iterable<Opcode?>?,
+    internal val strings: Iterable<String>?
 ) {
     /**
      * The result of the signature

--- a/src/main/kotlin/app/revanced/patcher/signature/resolver/SignatureResolver.kt
+++ b/src/main/kotlin/app/revanced/patcher/signature/resolver/SignatureResolver.kt
@@ -85,8 +85,6 @@ internal class SignatureResolver(
 
                     if (stringsList.isNotEmpty()) return null
                 }
-
-                compareOpcodes(signature, instructions)
             }
 
             return if (signature.opcodes == null) {

--- a/src/main/kotlin/app/revanced/patcher/signature/resolver/SignatureResolver.kt
+++ b/src/main/kotlin/app/revanced/patcher/signature/resolver/SignatureResolver.kt
@@ -127,15 +127,15 @@ internal class SignatureResolver(
         ) = buildList {
             val pattern = signature.opcodes!!
             for ((patternIndex, originalIndex) in (scanResult.startIndex until scanResult.endIndex).withIndex()) {
-                val originalOpcode = instructions.elementAt(originalIndex).opcode
+                val correctOpcode = instructions.elementAt(originalIndex).opcode
                 val patternOpcode = pattern.elementAt(patternIndex)
                 if (
                     patternOpcode != null && // unknown opcode
-                    originalOpcode != patternOpcode
+                    correctOpcode != patternOpcode
                 ) {
                     this.add(
                         PatternScanMethod.Fuzzy.Warning(
-                            originalOpcode, patternOpcode,
+                            correctOpcode, patternOpcode,
                             originalIndex, patternIndex,
                         )
                     )

--- a/src/test/kotlin/app/revanced/patcher/usage/ExamplePatch.kt
+++ b/src/test/kotlin/app/revanced/patcher/usage/ExamplePatch.kt
@@ -60,7 +60,8 @@ class ExamplePatch : Patch(
                 null,                 // Testing unknown opcodes.
                 Opcode.INVOKE_STATIC, // This is intentionally wrong to test the Fuzzy resolver.
                 Opcode.RETURN_VOID
-            )
+            ),
+            null
         )
     )
 ) {


### PR DESCRIPTION
This PR adds the capability to search for strings in a method by defining a list of strings in a `MethodSignature`. Currently inefficient.