### PR TITLE
fix: Remove version annotation

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/annotation/MetadataAnnotation.kt
+++ b/src/main/kotlin/app/revanced/patcher/annotation/MetadataAnnotation.kt
@@ -20,12 +20,3 @@ annotation class Description(
     val description: String,
 )
 
-
-/**
- * Annotation to version a [Patch].
- * @param version The version of a [Patch].
- */
-@Target(AnnotationTarget.CLASS)
-annotation class Version(
-    val version: String,
-)

--- a/src/main/kotlin/app/revanced/patcher/extensions/PatchExtensions.kt
+++ b/src/main/kotlin/app/revanced/patcher/extensions/PatchExtensions.kt
@@ -3,7 +3,6 @@ package app.revanced.patcher.extensions
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
-import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.Context
 import app.revanced.patcher.extensions.AnnotationExtensions.findAnnotationRecursively
 import app.revanced.patcher.patch.OptionsContainer
@@ -23,13 +22,7 @@ object PatchExtensions {
         get() = findAnnotationRecursively(Name::class)?.name ?: this.simpleName
 
     /**
-     * The version of a [Patch].
-     */
-    val Class<out Patch<Context>>.version
-        get() = findAnnotationRecursively(Version::class)?.version
-
-    /**
-     * Weather or not a [Patch] should be included.
+     * If a [Patch] should be included.
      */
     val Class<out Patch<Context>>.include
         get() = findAnnotationRecursively(app.revanced.patcher.patch.annotations.Patch::class)!!.include
@@ -53,7 +46,7 @@ object PatchExtensions {
         get() = findAnnotationRecursively(Compatibility::class)?.compatiblePackages
 
     /**
-     * Weather or not a [Patch] requires integrations.
+     * If a [Patch] requires integrations.
      */
     internal val Class<out Patch<Context>>.requiresIntegrations
         get() = findAnnotationRecursively(RequiresIntegrations::class) != null

--- a/src/main/kotlin/app/revanced/patcher/util/proxy/ClassProxy.kt
+++ b/src/main/kotlin/app/revanced/patcher/util/proxy/ClassProxy.kt
@@ -14,7 +14,7 @@ class ClassProxy internal constructor(
     val immutableClass: ClassDef,
 ) {
     /**
-     * Weather the proxy was actually used.
+     * If the proxy was actually used.
      */
     internal var resolved = false
 


### PR DESCRIPTION
Removed the mostly unused version annotation.

Patch versions were rarely ever incremented and the only thing that really matters is the date the packaged patches were released.