### PR TITLE
fix: Save XML files using UTF-8

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/util/Document.kt
+++ b/src/main/kotlin/app/revanced/patcher/util/Document.kt
@@ -40,7 +40,7 @@ class Document internal constructor(
             if (isAndroid) {
                 transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-16")
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
-                it.bufferedWriter().use { writer ->
+                it.bufferedWriter(charset = Charsets.UTF_8).use { writer ->
                     transformer.transform(DOMSource(this), StreamResult(writer))
                 }
             } else {
@@ -51,7 +51,6 @@ class Document internal constructor(
 
     private companion object {
         private val readerCount = mutableMapOf<File, Int>()
-        private val isAndroid =
-            System.getProperty("java.runtime.name") == "Android Runtime"
+        private val isAndroid = System.getProperty("java.runtime.name") == "Android Runtime"
     }
 }


### PR DESCRIPTION
A follow-up fixes for #339.
UTF-16 was incorrectly used to save XML files.
When setting the output encoding to UTF-16, a Writer must be used instead of an OutputStream to output the actual file in UTF-8.

Also, it turned out that when using OutputStream to output, it is not necessary to wrap them in `BufferedOutputStream`. See https://github.com/ReVanced/revanced-patcher/pull/339#issuecomment-3041446994
Therefore this PR reverts the changes in #347 and back to a simple `StreamResult(File f)`.

Additionally, addresses `System.getProperty()`'s nullability
And updated a comment