### PR TITLE
docs: Make license section use American spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ you can follow the [ReVanced documentation](https://github.com/ReVanced/revanced
 The documentation contains the fundamentals of ReVanced Patcher and how to use ReVanced Patcher to create patches.
 You can find it [here](https://github.com/ReVanced/revanced-patcher/tree/main/docs).
 
-## 📜 Licence
+## 📜 License
 
-ReVanced Patcher is licensed under the GPLv3 license. Please see the [licence file](LICENSE) for more information.
+ReVanced Patcher is licensed under the GPLv3 license. Please see the [license file](LICENSE) for more information.
 [tl;dr](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3) you may copy, distribute and modify ReVanced Patcher as long as you track changes/dates in source files.
 Any modifications to ReVanced Patcher must also be made available under the GPL,
 along with build & install instructions.


### PR DESCRIPTION
This PR is the same as #384 but change head repository because for some reason history of the main branch and dev branch is diverged

---------------------------------

From #384 

This is on my todolist for a very long time, I'll propagate this PR to other revanced repositories after the PR is merged within N+2 days unless requested change.

The license section uses British spelling of the word license ("licence"), which isn't intentional because ReVanced uses American spelling officially. 

Propagator!