### PR TITLE
docs: Update example gradle.properties keys to new key names

### DIFF
--- a/docs/1_setup.md
+++ b/docs/1_setup.md
@@ -95,8 +95,8 @@ Throughout the documentation, [ReVanced Patches](https://github.com/revanced/rev
 > Example `gradle.properties` file:
 >
 > ```properties
-> gpr.user = user
-> gpr.key = key
+> githubPackagesUsername = user
+> githubPackagesPassword = key
 > ```
 
 3. Open the project in your IDE


### PR DESCRIPTION
Does not work with
`gpr.user` and `grp.key`:
```
* What went wrong:
Error resolving plugin [id: 'app.revanced.patches', version: '1.0.0-dev.10']
> The following Gradle properties are missing for 'githubPackages' credentials:
    - githubPackagesUsername
    - githubPackagesPassword

```