### PR TITLE
fix: sanitize fake png resources before compile

### DIFF
--- a/patcher/src/commonMain/kotlin/app/revanced/patcher/patch/ResourceFileSanitizer.kt
+++ b/patcher/src/commonMain/kotlin/app/revanced/patcher/patch/ResourceFileSanitizer.kt
@@ -1,0 +1,141 @@
+package app.revanced.patcher.patch
+
+import java.io.File
+import java.nio.file.Files
+import java.util.Locale
+import java.util.logging.Logger
+import java.util.stream.Collectors
+
+internal object ResourceFileSanitizer {
+    private val pngMagic = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    private val jpegMagic = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+
+    fun sanitizePngResources(
+        resDirectory: File,
+        logger: Logger,
+    ): List<Result> {
+        if (!resDirectory.exists()) return emptyList()
+
+        val paths = Files.walk(resDirectory.toPath())
+        return try {
+            paths
+                .filter(Files::isRegularFile)
+                .map { it.toFile() }
+                .filter { it.name.lowercase(Locale.ROOT).endsWith(".png") }
+                .map { file -> sanitizePngResource(resDirectory, file, logger) }
+                .filter { it.action != Action.PRESERVED }
+                .collect(Collectors.toList())
+        } finally {
+            paths.close()
+        }
+    }
+
+    fun detectFormat(file: File): Format {
+        val header = ByteArray(16)
+        val readBytes =
+            file.inputStream().use { inputStream ->
+                inputStream.read(header)
+            }.coerceAtLeast(0)
+
+        val bytes = header.copyOf(readBytes)
+
+        return when {
+            bytes.startsWith(pngMagic) -> Format.PNG
+            bytes.startsWith(jpegMagic) -> Format.JPEG
+            bytes.isWebP() -> Format.WEBP
+            bytes.isIsoBmff("avif") || bytes.isIsoBmff("avis") -> Format.AVIF
+            bytes.isIsoBmff("heic") || bytes.isIsoBmff("heix") || bytes.isIsoBmff("hevc") || bytes.isIsoBmff("hevx") ->
+                Format.HEIF
+            else -> Format.UNKNOWN
+        }
+    }
+
+    private fun sanitizePngResource(
+        resDirectory: File,
+        file: File,
+        logger: Logger,
+    ): Result {
+        val format = detectFormat(file)
+        if (format == Format.PNG) return Result(file, format, Action.PRESERVED)
+
+        val relativePath = file.relativeTo(resDirectory).path
+        if (file.name.lowercase(Locale.ROOT).endsWith(".9.png")) {
+            throw PatchException(
+                "Resource sanitization failed for $relativePath. Detected format: $format. " +
+                    "Nine-patch resources must remain valid PNG files and cannot be renamed safely. " +
+                    "Replace the file with a valid .9.png resource.",
+            )
+        }
+
+        val extension =
+            format.resourceExtension ?: throw PatchException(
+                "Resource sanitization failed for $relativePath. Detected format: $format. " +
+                    "The file has a .png extension but is not a PNG image, and the real format could not be detected. " +
+                    "Replace it with a valid PNG or a supported Android drawable format.",
+            )
+
+        val renamedFile = file.resolveSibling(file.nameWithoutExtension + extension)
+        if (renamedFile.exists()) {
+            throw PatchException(
+                "Resource sanitization failed for $relativePath. Detected format: $format. " +
+                    "Cannot rename to ${renamedFile.name} because that file already exists. " +
+                    "Remove the duplicate resource or replace $relativePath with a valid PNG.",
+            )
+        }
+
+        Files.move(file.toPath(), renamedFile.toPath())
+        logger.warning(
+            "Sanitized resource ${file.relativeTo(resDirectory)}: detected $format content in a .png file; " +
+                "renamed to ${renamedFile.relativeTo(resDirectory)} before resource compilation.",
+        )
+
+        return Result(renamedFile, format, Action.RENAMED)
+    }
+
+    private fun ByteArray.startsWith(prefix: ByteArray) =
+        size >= prefix.size && prefix.indices.all { index -> this[index] == prefix[index] }
+
+    private fun ByteArray.isWebP() =
+        size >= 12 &&
+            this[0] == 'R'.code.toByte() &&
+            this[1] == 'I'.code.toByte() &&
+            this[2] == 'F'.code.toByte() &&
+            this[3] == 'F'.code.toByte() &&
+            this[8] == 'W'.code.toByte() &&
+            this[9] == 'E'.code.toByte() &&
+            this[10] == 'B'.code.toByte() &&
+            this[11] == 'P'.code.toByte()
+
+    private fun ByteArray.isIsoBmff(brand: String) =
+        size >= 12 &&
+            this[4] == 'f'.code.toByte() &&
+            this[5] == 't'.code.toByte() &&
+            this[6] == 'y'.code.toByte() &&
+            this[7] == 'p'.code.toByte() &&
+            this[8] == brand[0].code.toByte() &&
+            this[9] == brand[1].code.toByte() &&
+            this[10] == brand[2].code.toByte() &&
+            this[11] == brand[3].code.toByte()
+
+    enum class Format(
+        val resourceExtension: String?,
+    ) {
+        PNG(".png"),
+        JPEG(".jpg"),
+        WEBP(".webp"),
+        AVIF(".avif"),
+        HEIF(null),
+        UNKNOWN(null),
+    }
+
+    enum class Action {
+        PRESERVED,
+        RENAMED,
+    }
+
+    data class Result(
+        val file: File,
+        val detectedFormat: Format,
+        val action: Action,
+    )
+}

--- a/patcher/src/commonMain/kotlin/app/revanced/patcher/patch/ResourcePatchContext.kt
+++ b/patcher/src/commonMain/kotlin/app/revanced/patcher/patch/ResourcePatchContext.kt
@@ -148,6 +148,8 @@ class ResourcePatchContext internal constructor(
                         apkInfo.usesFramework.ids.map { id -> getFrameworkApk(id, null) }
                     }.toTypedArray()
 
+                ResourceFileSanitizer.sanitizePngResources(resPath, logger)
+
                 AaptInvoker(
                     resourceConfig,
                     apkInfo,

--- a/patcher/src/jvmTest/kotlin/app/revanced/patcher/patch/ResourceFileSanitizerTest.kt
+++ b/patcher/src/jvmTest/kotlin/app/revanced/patcher/patch/ResourceFileSanitizerTest.kt
@@ -1,0 +1,110 @@
+package app.revanced.patcher.patch
+
+import org.junit.jupiter.api.assertThrows
+import java.nio.file.Files
+import java.util.logging.Logger
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ResourceFileSanitizerTest {
+    private val logger = Logger.getLogger(ResourceFileSanitizerTest::class.java.name)
+
+    @Test
+    fun `detects fake png file formats`() {
+        withTempResourceDirectory { resDirectory ->
+            val jpeg = resDirectory.resolve("drawable/fake_jpeg.png")
+            val webp = resDirectory.resolve("drawable/fake_webp.png")
+            val avif = resDirectory.resolve("drawable/fake_avif.png")
+            val heif = resDirectory.resolve("drawable/fake_heif.png")
+
+            Files.write(jpeg, byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0x00))
+            Files.write(webp, byteArrayOf(0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50))
+            Files.write(avif, byteArrayOf(0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66))
+            Files.write(heif, byteArrayOf(0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63))
+
+            assertEquals(ResourceFileSanitizer.Format.JPEG, ResourceFileSanitizer.detectFormat(jpeg.toFile()))
+            assertEquals(ResourceFileSanitizer.Format.WEBP, ResourceFileSanitizer.detectFormat(webp.toFile()))
+            assertEquals(ResourceFileSanitizer.Format.AVIF, ResourceFileSanitizer.detectFormat(avif.toFile()))
+            assertEquals(ResourceFileSanitizer.Format.HEIF, ResourceFileSanitizer.detectFormat(heif.toFile()))
+        }
+    }
+
+    @Test
+    fun `preserves valid png files`() {
+        withTempResourceDirectory { resDirectory ->
+            val png = resDirectory.resolve("drawable/icon.png")
+            val bytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00)
+            Files.write(png, bytes)
+
+            val results = ResourceFileSanitizer.sanitizePngResources(resDirectory.toFile(), logger)
+
+            assertTrue(results.isEmpty())
+            assertTrue(png.toFile().exists())
+            assertContentEquals(bytes, png.toFile().readBytes())
+        }
+    }
+
+    @Test
+    fun `preserves valid nine patch png files`() {
+        withTempResourceDirectory { resDirectory ->
+            val ninePatch = resDirectory.resolve("drawable/button.9.png")
+            val bytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00)
+            Files.write(ninePatch, bytes)
+
+            ResourceFileSanitizer.sanitizePngResources(resDirectory.toFile(), logger)
+
+            assertTrue(ninePatch.toFile().exists())
+            assertContentEquals(bytes, ninePatch.toFile().readBytes())
+        }
+    }
+
+    @Test
+    fun `rejects fake nine patch png files`() {
+        withTempResourceDirectory { resDirectory ->
+            val ninePatch = resDirectory.resolve("drawable/button.9.png")
+            Files.write(ninePatch, byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0x00))
+
+            val exception =
+                assertThrows<PatchException> {
+                    ResourceFileSanitizer.sanitizePngResources(resDirectory.toFile(), logger)
+                }
+
+            assertTrue(exception.message!!.contains("Nine-patch resources must remain valid PNG files"))
+            assertTrue(ninePatch.toFile().exists())
+        }
+    }
+
+    @Test
+    fun `renames fake png resource before compile preserving resource name`() {
+        withTempResourceDirectory { resDirectory ->
+            val fakePng = resDirectory.resolve("drawable-xxhdpi/bs6.png")
+            val bytes = byteArrayOf(0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50)
+            Files.write(fakePng, bytes)
+
+            val results = ResourceFileSanitizer.sanitizePngResources(resDirectory.toFile(), logger)
+            val sanitized = resDirectory.resolve("drawable-xxhdpi/bs6.webp")
+
+            assertEquals(1, results.size)
+            assertEquals(ResourceFileSanitizer.Format.WEBP, results.single().detectedFormat)
+            assertEquals(ResourceFileSanitizer.Action.RENAMED, results.single().action)
+            assertFalse(fakePng.toFile().exists())
+            assertTrue(sanitized.toFile().exists())
+            assertContentEquals(bytes, sanitized.toFile().readBytes())
+        }
+    }
+
+    private fun withTempResourceDirectory(block: (java.nio.file.Path) -> Unit) {
+        val directory = Files.createTempDirectory("resource-sanitizer-test")
+        Files.createDirectories(directory.resolve("drawable"))
+        Files.createDirectories(directory.resolve("drawable-xxhdpi"))
+
+        try {
+            block(directory)
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a pre-AAPT resource sanitizer for decoded APK resources.
- Scans `res/**/*.png`, validates the PNG magic bytes, detects JPEG/WebP/AVIF/HEIF content, and renames fake `.png` files to a supported Android drawable extension when safe.
- Keeps valid `.png` and `.9.png` resources unchanged; invalid `.9.png` files fail with an actionable `PatchException` instead of reaching AAPT2 as a generic PNG signature error.
- Adds JVM tests for fake PNG detection, valid PNG preservation, nine-patch preservation/rejection, and a minimal fake `bs6.png` fixture that is sanitized to `bs6.webp` before compile.

## Root cause
Some APKs can contain decoded drawable files with a `.png` extension while the actual bytes are another image format, such as WebP. AAPT2 validates by extension and fails with `failed to read PNG signature`. The resource is already in the patcher's decoded resource directory, so the robust fix belongs in `revanced-patcher` before `AaptInvoker.invoke`, not in Manager UI handling.

## Behavior
- PNG magic bytes: preserve.
- JPEG/WebP/AVIF: rename to `.jpg`, `.webp`, or `.avif`, preserving the resource name such as `@drawable/bs6`.
- HEIF/unknown or invalid `.9.png`: fail with a clear message naming the file, detected format, and suggested action.

## Testing
- `git diff --cached --check` passed before commit.
- `./gradlew :patcher:jvmTest` could not complete in this environment because the available GitHub token lacks `read:packages` for `app.revanced:apktool-lib:2.10.1.1` and `app.revanced:multidexlib2:3.0.3.r3` from GitHub Packages (401 Unauthorized).

## Notes
- I could not update the separate TikTok `Disable telemetry` fingerprint because `revanced/revanced-patches` currently returns GitHub DMCA 403 from this environment.